### PR TITLE
upload contests

### DIFF
--- a/make/ContestMakefile
+++ b/make/ContestMakefile
@@ -19,6 +19,11 @@ check-notes:
 contest-pdf:
 	'$(TOOLS_MAKE_DIR)/build-contest-pdf.sh' contest.pdf $(PROBLEMS)
 
+.PHONY: upload
+upload:
+	$(foreach p,$(PROBLEMS),'$(MAKE)' -C $(p) pack;)
+	'$(TOOLS_MAKE_DIR)/upload.py' -c
+
 ifndef VERBOSE
 .SILENT:
 endif

--- a/make/Makefile
+++ b/make/Makefile
@@ -273,7 +273,7 @@ clean:
 .PHONY: upload
 upload: build/$(PROBLEM_ID).zip $(if $(VALIDATOR),build/$(PROBLEM_ID)-validator.zip)
 	echo Uploading archive
-	'$(TOOLS_MAKE_DIR)/upload.py' 'build/$(PROBLEM_ID).zip' $(if $(VALIDATOR),'build/$(PROBLEM_ID)-validator.zip')
+	'$(TOOLS_MAKE_DIR)/upload.py' -p 'build/$(PROBLEM_ID).zip' $(if $(VALIDATOR),-v 'build/$(PROBLEM_ID)-validator.zip')
 
 .PHONY: check-notes
 check-notes:

--- a/make/upload.py
+++ b/make/upload.py
@@ -199,7 +199,7 @@ def create_contest(base_url, auth, session):
         exit_error('Wrong format! (%d.%m.%y %H:%M)')
 
     end_time = questionary.text('End time:', default=(
-        datetime.now() + timedelta(weeks=2)).strftime('%d.%m.%y %H:%M')).unsafe_ask()
+        datetime.now() + timedelta(weeks=1)).strftime('%d.%m.%y %H:%M')).unsafe_ask()
 
     try:
         end_time = datetime.strptime(end_time, '%d.%m.%y %H:%M')
@@ -251,9 +251,11 @@ def get_judge_data():
 
     if base_url[-1] == '/':
         base_url = base_url[:-1]
-    auth = HTTPBasicAuth(username, password)
 
+    auth = HTTPBasicAuth(username, password)
     session = requests.Session()
+    # auth is used for api requests and the logged in session is needed for calls that are not supported by the api
+
     csrf_token = get_csrf_token(session, base_url)
     if not login(session, base_url, csrf_token, username, password):
         exit_error('Invalid login data')

--- a/make/upload.py
+++ b/make/upload.py
@@ -209,7 +209,7 @@ def create_contest(base_url, auth, session):
         exit_error('Wrong format! (%d.%m.%y %H:%M)')
 
     categories = get_team_categories(base_url, session)
-    if contest['contest[name]'].endswith('testing'):
+    if contest['contest[shortname]'].endswith('testing'):
         category_id = [category['id'] for category in categories if category['name'] == 'Staff']
         print('Using category Staff for testing contest')
     else:

--- a/make/upload.py
+++ b/make/upload.py
@@ -11,8 +11,7 @@ import toml
 import yaml
 from lxml import html
 from requests.auth import HTTPBasicAuth
-from dataclasses import dataclass
-from typing import List, Optional, NamedTuple
+from typing import List, Optional
 
 
 def exit_error(message):

--- a/make/upload.py
+++ b/make/upload.py
@@ -350,8 +350,9 @@ def main():
                         help='upload a contest?')
 
     args = parser.parse_args()
+    print(args)
 
-    if args.contest != (args.problem_zip is None or args.validator_zip is None):
+    if args.contest != (args.problem_zip is None and args.validator_zip is None):
         exit_error('Specify either contest or problem data')
 
     base_url, auth, session = get_judge_data()

--- a/make/upload.py
+++ b/make/upload.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
 import sys
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
-
+import argparse
 import dateutil.parser
 import questionary
 import requests
 import toml
+import yaml
 from lxml import html
 from requests.auth import HTTPBasicAuth
+from dataclasses import dataclass
+from typing import List, Optional, NamedTuple
 
 
 def exit_error(message):
@@ -30,7 +33,23 @@ def get_login_entries():
         exit_error(f'login.toml not found or not accessible:\n\n{err}')
 
 
-def is_active_testing_contest(contest):
+def get_team_categories(base_url, session):
+    response = session.get(base_url + '/jury/categories')
+    tree = html.document_fromstring(response.content)
+    table_rows = tree.xpath(f"//tbody/tr")[0]
+    
+    categories = []
+    for i, n in zip(table_rows.xpath('//td[1]/a/text()'), table_rows.xpath('//td[4]/a/text()')):
+
+        categories.append({
+            'id': i.strip(),
+            'name': n.strip()
+        })
+
+    return categories
+
+
+def is_contest(contest, only_testing=False, also_future=True):
     now = datetime.now(timezone.utc)
     if 'start_time' not in contest or contest['start_time'] is None or 'end_time' not in contest or contest['end_time'] is None:
         return False
@@ -38,20 +57,20 @@ def is_active_testing_contest(contest):
     start_time = dateutil.parser.parse(contest['start_time'])
     end_time = dateutil.parser.parse(contest['end_time'])
     shortname = contest['shortname']
-    return shortname.endswith('testing') and start_time <= now <= end_time
+    return (shortname.endswith('testing') or not only_testing) and (start_time <= now or also_future) and now <= end_time
 
 
-def get_active_testing_contest(base_url, auth):
+def get_contest(base_url, auth, only_testing=False, also_future=True):
     data = requests.get(f'{base_url}/api/v4/contests', auth=auth).json()
     return [
         contest for contest in data
-        if is_active_testing_contest(contest)
+        if is_contest(contest, only_testing=only_testing, also_future=also_future)
     ]
 
 
 def problem_id_by_name(session, base_url, problem_name):
-    upload_response = session.get(base_url + '/jury/problems')
-    tree = html.document_fromstring(upload_response.content)
+    response = session.get(base_url + '/jury/problems')
+    tree = html.document_fromstring(response.content)
     problem_links = tree.xpath(
         f"//table/tbody/tr/td/a[contains(text(), '{problem_name}')]/@href")
     if problem_links:
@@ -84,6 +103,24 @@ def upload_problem(base_url, auth, contest_id, filename):
     if 'Saved problem' in upload_response.text:
         return True
     return upload_response.status_code
+
+
+def link_problem(base_url, auth, session, contest_id, problem_name):
+    problem_id = problem_id_by_name(session, base_url, problem_name)
+
+    if problem_id is False:
+        exit_error('trying to link nonexistant problem')
+
+    response = requests.put(
+        f'{base_url}/api/v4/contests/{contest_id}/problems/{problem_id}', auth=auth, data={'label': problem_name, })
+
+    if response.status_code != 200:
+        if 'already linked' not in str(response.content):
+            exit_error(
+                f'linking problem {problem_name} failed with code {response.status_code}\n {response.content}'
+                )
+
+    print(f'-> problem {problem_name} linked successfully')
 
 
 def get_csrf_token(session, base_url):
@@ -121,9 +158,8 @@ def delete_validator(session, base_url, validator_name):
 def upload_validator(session, base_url, filename):
     data = {'executable_upload[type]': 'compare'}
     files = {'executable_upload[archives][]': open(filename, 'rb')}
-    upload_response = session.post(base_url + '/jury/executables/add',
-                                   data,
-                                   files=files)
+    upload_response = session.post(
+        base_url + '/jury/executables/add', data, files=files)
     return upload_response.status_code
 
 
@@ -131,7 +167,74 @@ def prompt_choice(message, choices):
     return questionary.select(message=message, choices=choices).unsafe_ask()
 
 
-def main():
+def create_contest(base_url, auth, session):
+    contest = {
+        'contest[starttimeEnabled]': 1,
+        'contest[freezetimeString]': '',
+        'contest[unfreezetimeString]': '',
+        'contest[deactivatetimeString]': '',
+        'contest[allowSubmit]': 1,
+        'contest[processBalloons]': 0,
+        'contest[runtimeAsScoreTiebreaker]': 1,
+        'contest[medalsEnabled]': 0,
+        'contest[goldMedals]': 4,
+        'contest[silverMedals]': 4,
+        'contest[bronzeMedals]': 4,
+        'contest[public]': 0,
+        'contest[openToAllTeams]': 0,
+        'contest[enabled]': 1
+    }
+
+    contest['contest[shortname]'] = questionary.text(
+        'Short name:').unsafe_ask()
+    contest['contest[name]'] = questionary.text(
+        'Name:', default=contest['contest[shortname]']).unsafe_ask()
+    start_time = questionary.text(
+        'Start time:', default=datetime.now().strftime('%d.%m.%y %H:%M')).unsafe_ask()
+
+    try:
+        start_time = datetime.strptime(start_time, '%d.%m.%y %H:%M')
+        contest['contest[starttimeString]'] = start_time.strftime(
+            '%Y-%m-%d %H:%M:00 Europe/Berlin')
+    except:
+        exit_error('Wrong format! (%d.%m.%y %H:%M)')
+
+    end_time = questionary.text('End time:', default=(
+        datetime.now() + timedelta(weeks=2)).strftime('%d.%m.%y %H:%M')).unsafe_ask()
+
+    try:
+        end_time = datetime.strptime(end_time, '%d.%m.%y %H:%M')
+        contest['contest[endtimeString]'] = end_time.strftime(
+            '%Y-%m-%d %H:%M:00 Europe/Berlin')
+    except:
+        exit_error('Wrong format! (%d.%m.%y %H:%M)')
+
+    categories = get_team_categories(base_url, session)
+    if contest['contest[name]'].endswith('testing'):
+        category_id = [category['id'] for category in categories if category['name'] == 'Staff']
+        print('Using category Staff for testing contest')
+    else:
+        category_id = questionary.select('Which category to add', [
+            questionary.Choice(title=category['name'], value=category['id'])
+            for category in categories
+        ]).unsafe_ask()
+
+    contest['contest[teamCategories][]'] = category_id
+    contest['contest[activatetimeString]'] = contest['contest[starttimeString]']
+
+    response = session.post(f'{base_url}/jury/contests/add', data=contest)
+
+    if response.status_code != 200:
+        exit_error(f'failed with status code {response.status_code}')
+
+    contests = requests.get(f'{base_url}/api/v4/contests', auth=auth).json()
+    contest_id = [c['id'] for c in contests if c['shortname']
+                  == contest['contest[shortname]']][0]
+
+    return contest_id
+
+
+def get_judge_data():
     judges = get_login_entries()
     if any('contests' in judge for judge in judges.values()):
         print('login.toml contains contest list which is no longer needed')
@@ -144,60 +247,119 @@ def main():
 
     username = judges[base_url]['username']
     password = judges[base_url].get('password')
-    auth = HTTPBasicAuth(username, password)
-
-    if base_url[-1] == '/':
-        base_url = base_url[:-1]
-
     if not password:
         password = questionary.password(message='Judge password').unsafe_ask()
 
-    contests = get_active_testing_contest(base_url, auth)
-    if not contests:
-        exit_error('No running testing contests found for judge '
-                   '(shortname must end in "testing")')
-
-    contest_id = prompt_choice('Which contest to add to', [
-        questionary.Choice(title=contest['shortname'], value=contest['id'])
-        for contest in contests
-    ])
+    if base_url[-1] == '/':
+        base_url = base_url[:-1]
+    auth = HTTPBasicAuth(username, password)
 
     session = requests.Session()
     csrf_token = get_csrf_token(session, base_url)
     if not login(session, base_url, csrf_token, username, password):
         exit_error('Invalid login data')
 
-    problem_name = name_by_filename(sys.argv[1])
+    return base_url, auth, session
 
-    if len(sys.argv) == 3:
+
+def get_contest_id(base_url, auth, session):
+    contests = get_contest(base_url, auth)
+    if not contests:
+        exit_error(
+            'No running testing contests found for judge (shortname must end in "testing")')
+
+    contest_id = prompt_choice('Which contest to add to', [
+        questionary.Choice(title=contest['shortname'], value=contest['id'])
+        for contest in contests
+    ] + ['*new*'])
+
+    if contest_id == '*new*':
+        contest_id = create_contest(base_url, auth, session)
+
+    return contest_id
+
+
+def upload_problem_main(base_url, auth, session, problem_zip, validator_zip, contest_id=None):
+    if contest_id is None:
+        contest_id = get_contest_id(base_url, auth, session)
+
+    if validator_zip is not None:
         # Upload the validator first, so that the problem can be linked to it
         # using its domjudge-problem.ini
 
-        validator_name = name_by_filename(sys.argv[2])
+        validator_name = name_by_filename(validator_zip)
         if validator_on_judge(session, base_url, validator_name):
-            if not questionary.confirm(
+            if questionary.confirm(
                     'Validator already exists. Delete and reupload?').unsafe_ask():
-                exit(1)
-            delete_validator(session, base_url, validator_name)
+                delete_validator(session, base_url, validator_name)
 
-        result = upload_validator(session, base_url, sys.argv[2])
-        if result == 200:
-            print('-> Validator uploaded successfully')
+        if not validator_on_judge(session, base_url, validator_name):
+            result = upload_validator(session, base_url, validator_zip)
+            if result == 200:
+                print('-> Validator uploaded successfully')
+            else:
+                exit_error(
+                    f'Validator upload failed with status code {result}')
+
+    if problem_zip is not None:
+        problem_name = name_by_filename(problem_zip)
+        if problem_on_judge(session, base_url, problem_name):
+            if not questionary.confirm(
+                    'Problem already exists. Delete and reupload?').unsafe_ask():
+                link_problem(base_url, auth, session, contest_id, problem_name)
+                return
+
+            delete_problem(session, base_url, problem_name)
+
+        result = upload_problem(base_url, auth, contest_id, problem_zip)
+        if result is True:
+            print('-> Problem uploaded successfully')
         else:
-            exit_error(f'Validator upload failed with status code {result}')
+            exit_error(f'Problem upload failed with status code {result}')
 
-    if problem_on_judge(session, base_url, problem_name):
-        if not questionary.confirm(
-                'Problem already exists. Delete and reupload?').unsafe_ask():
-            exit(1)
 
-        delete_problem(session, base_url, problem_name)
+def upload_contest_main(base_url, auth, session):
+    contest_id = get_contest_id(base_url, auth, session)
 
-    result = upload_problem(base_url, auth, contest_id, sys.argv[1])
-    if result is True:
-        print('-> Problem uploaded successfully')
+    problem_paths = [f.path for f in os.scandir('.') if f.is_dir()]
+    for problem_path in problem_paths:
+        problem_zip = os.path.join(
+            problem_path, 'build', f'{os.path.basename(problem_path)}.zip')
+        if not os.path.exists(problem_zip):
+            exit_error(f'{problem_zip} does not exist!')
+
+        validator_zip = os.path.join(
+            problem_path, 'build', f'{os.path.basename(problem_path)}-validator.zip')
+        if not os.path.exists(validator_zip):
+            validator_zip = None
+
+        print()
+        print(f'-> Uploading problem {os.path.basename(problem_path)}')
+        upload_problem_main(base_url, auth, session, problem_zip,
+                            validator_zip, contest_id=contest_id)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--problem-zip', '-p',
+                        help='the filename of a problem to upload')
+    parser.add_argument('--validator-zip', '-v',
+                        help='the filename of a validator zip to upload')
+    parser.add_argument('--contest', '-c', action='store_true',
+                        help='upload a contest?')
+
+    args = parser.parse_args()
+
+    if args.contest != (args.problem_zip is None or args.validator_zip is None):
+        exit_error('Specify either contest or problem data')
+
+    base_url, auth, session = get_judge_data()
+
+    if args.contest:
+        upload_contest_main(base_url, auth, session)
     else:
-        exit_error(f'Problem upload failed with status code {result}')
+        upload_problem_main(base_url, auth, session,
+                            args.problem_zip, args.validator_zip)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds functionality to upload entire contests and create new contests. All problems from the folder are uploaded and linked to the contests or reuploaded or only linked if they already exist.
You can also use `make upload` to just link problems to an existing contest (like upsolving).